### PR TITLE
Remove the "stable" filtering in available_release response

### DIFF
--- a/internal/provider/upgrade.go
+++ b/internal/provider/upgrade.go
@@ -34,10 +34,6 @@ func ListVersions(e *pluggable.Event) pluggable.EventResponse {
 
 	semver.Sort(displayTags)
 
-	if e.Data == "stable" {
-		keepOnlyStable(displayTags)
-	}
-
 	versions, err := json.Marshal(displayTags)
 	resp := &pluggable.EventResponse{
 		Data: string(versions),
@@ -48,15 +44,4 @@ func ListVersions(e *pluggable.Event) pluggable.EventResponse {
 	}
 
 	return *resp
-}
-
-func keepOnlyStable(versions []string) []string {
-	result := []string{}
-	for _, v := range versions {
-		if semver.Prerelease(v) == "" {
-			result = append(result, v)
-		}
-	}
-
-	return result
 }

--- a/tests/provider_upgrade_test.go
+++ b/tests/provider_upgrade_test.go
@@ -23,7 +23,7 @@ var _ = Describe("provider upgrade test", Label("provider-upgrade"), func() {
 	})
 
 	Context("agent.available_releases event", func() {
-		It("returns all the available versions ordered", func() {
+		It("returns the available versions ordered", func() {
 			resultStr, _ := machine.SSHCommand(`echo '{}' | /system/providers/agent-provider-kairos agent.available_releases`)
 
 			var result pluggable.EventResponse
@@ -42,27 +42,6 @@ var _ = Describe("provider upgrade test", Label("provider-upgrade"), func() {
 			semver.Sort(sorted)
 
 			Expect(sorted).To(Equal(versions))
-			Expect(versions).To(ContainElement("v1.0.0-rc2-k3sv1.23.9-k3s1"))
-		})
-
-		When("'stable' versions are requested", func() {
-			It("returns only stable versions", func() {
-				resultStr, _ := machine.SSHCommand(`echo '{"data": "stable"}' | /system/providers/agent-provider-kairos agent.available_releases`)
-
-				var result pluggable.EventResponse
-
-				err := json.Unmarshal([]byte(resultStr), &result)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(result.Data).ToNot(BeEmpty())
-				var versions []string
-				json.Unmarshal([]byte(result.Data), &versions)
-
-				Expect(versions).ToNot(BeEmpty())
-				for _, v := range versions {
-					Expect(v).ToNot(MatchRegexp(`-rc\d+-`))
-				}
-			})
 		})
 	})
 })


### PR DESCRIPTION
because all our versions are considered pre-releases in standard semantic versioning. E.g.

v1.0.0-k3sv1.23.9-k3s1

this also has a "pre-release" part (everything after the `-`).