### PR TITLE
:bug: Skip SELINUX warnings in fedora builds

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -121,8 +121,8 @@ docker:
 
     ENV INSTALL_K3S_BIN_DIR="/usr/bin"
     RUN curl -sfL https://get.k3s.io > installer.sh \
-        && INSTALL_K3S_SKIP_START="true" INSTALL_K3S_SKIP_ENABLE="true" INSTALL_K3S_SKIP_SELINUX_RPM="true" bash installer.sh \
-        && INSTALL_K3S_SKIP_START="true" INSTALL_K3S_SKIP_ENABLE="true" INSTALL_K3S_SKIP_SELINUX_RPM="true" bash installer.sh agent \
+        && INSTALL_K3S_SELINUX_WARN=true INSTALL_K3S_SKIP_START="true" INSTALL_K3S_SKIP_ENABLE="true" INSTALL_K3S_SKIP_SELINUX_RPM="true" bash installer.sh \
+        && INSTALL_K3S_SELINUX_WARN=true INSTALL_K3S_SKIP_START="true" INSTALL_K3S_SKIP_ENABLE="true" INSTALL_K3S_SKIP_SELINUX_RPM="true" bash installer.sh agent \
         && rm -rf installer.sh
     RUN luet install -y utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip && luet cleanup
     # Drop env files from k3s as we will generate them


### PR DESCRIPTION
SELinux has its own story: https://github.com/kairos-io/kairos/issues/114. We temporary disable it here, as there is no support at OS level currently.

Fixes: https://github.com/kairos-io/kairos/issues/376
See also pipeline failures at: https://github.com/kairos-io/provider-kairos/actions/runs/3665967843

Signed-off-by: mudler <mudler@c3os.io>