### PR TITLE
:bug: Fixup detection if block is missing

### DIFF
--- a/internal/provider/bootstrap.go
+++ b/internal/provider/bootstrap.go
@@ -234,7 +234,7 @@ func oneTimeBootstrap(l logging.StandardLogger, c *providerConfig.Config, vpnSet
 		return err
 	}
 
-	if c.P2P.VPNNeedsCreation() {
+	if c.P2P != nil && c.P2P.VPNNeedsCreation() {
 		if err := vpnSetupFN(); err != nil {
 			return err
 		}


### PR DESCRIPTION
p2p block is optional, thus we might panic otherwise here

Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>