### PR TITLE
Upgrade urfave/cli and make register's config flag required

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,6 +188,7 @@ require (
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/twpayne/go-vfs v1.7.2 // indirect
+	github.com/urfave/cli/v2 v2.23.7 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
@@ -200,6 +201,7 @@ require (
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
 	github.com/xlzd/gotp v0.0.0-20220110052318-fab697c03c2c // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1697,6 +1697,8 @@ github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.10 h1:p8Fspmz3iTctJstry1PYS3HVdllxnEzTEsgIgtxTrCk=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.23.7 h1:YHDQ46s3VghFHFf1DdF+Sh7H4RqhcM+t0TmZRJx4oJY=
+github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/uudashr/gocognit v1.0.5/go.mod h1:wgYz0mitoKOTysqxTDMOUXg+Jb5SvtihkfmugIZYpEA=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -1747,6 +1749,8 @@ github.com/xlzd/gotp v0.0.0-20220110052318-fab697c03c2c/go.mod h1:ndLJ3JKzi3xLmU
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yeya24/promlinter v0.1.0/go.mod h1:rs5vtZzeBHqqMwXqFScncpCF6u06lezhZepno9AB1Oc=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=

--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mudler/edgevpn/pkg/services"
 	"github.com/mudler/edgevpn/pkg/vpn"
 	qr "github.com/mudler/go-nodepair/qrcode"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // bridge is just starting a VPN with edgevpn to the given network token.

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -10,7 +10,7 @@ import (
 	edgeVPNClient "github.com/mudler/edgevpn/api/client"
 
 	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v1"
 
 	"github.com/mudler/edgevpn/api/client/service"
@@ -36,8 +36,12 @@ func Start() error {
 	app := &cli.App{
 		Name:    "kairos",
 		Version: "0.1",
-		Author:  "Ettore Di Giacinto",
-		Usage:   "kairos CLI to bootstrap, upgrade, connect and manage a kairos network",
+		Authors: []*cli.Author{
+			{
+				Name: "Ettore Di Giacinto",
+			},
+		},
+		Usage: "kairos CLI to bootstrap, upgrade, connect and manage a kairos network",
 		Description: `
 The kairos CLI can be used to manage a kairos box and perform all day-two tasks, like:
 - register a node
@@ -52,7 +56,7 @@ For all the example cases, see: https://docs.kairos.io .
 `,
 		UsageText: ``,
 		Copyright: "Ettore Di Giacinto",
-		Commands: []cli.Command{
+		Commands: []*cli.Command{
 			{
 				Name:      "recovery-ssh-server",
 				UsageText: "recovery-ssh-server",
@@ -63,21 +67,21 @@ For all the example cases, see: https://docs.kairos.io .
 				ArgsUsage: "Spawn up a simple standalone ssh server over p2p",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:   "token",
-						EnvVar: "TOKEN",
+						Name:    "token",
+						EnvVars: []string{"TOKEN"},
 					},
 					&cli.StringFlag{
-						Name:   "service",
-						EnvVar: "SERVICE",
+						Name:    "service",
+						EnvVars: []string{"SERVICE"},
 					},
 					&cli.StringFlag{
-						Name:   "password",
-						EnvVar: "PASSWORD",
+						Name:    "password",
+						EnvVars: []string{"PASSWORD"},
 					},
 					&cli.StringFlag{
-						Name:   "listen",
-						EnvVar: "LISTEN",
-						Value:  recoveryAddr,
+						Name:    "listen",
+						EnvVars: []string{"LISTEN"},
+						Value:   recoveryAddr,
 					},
 				},
 				Action: func(c *cli.Context) error {
@@ -125,10 +129,9 @@ For all the example cases, see: https://docs.kairos.io .
 				},
 
 				Action: func(c *cli.Context) error {
-					args := c.Args()
 					var ref string
-					if len(args) == 1 {
-						ref = args[0]
+					if c.Args().Len() == 1 {
+						ref = c.Args().First()
 					}
 
 					return register(c.String("log-level"), ref, c.String("config"), c.String("device"), c.Bool("reboot"), c.Bool("poweroff"))
@@ -171,13 +174,13 @@ For all the example cases, see: https://docs.kairos.io .
 					&cli.StringFlag{
 						Name:     "network-token",
 						Required: false,
-						EnvVar:   "NETWORK_TOKEN",
+						EnvVars:  []string{"NETWORK_TOKEN"},
 						Usage:    "Network token to connect over",
 					},
 					&cli.StringFlag{
 						Name:     "log-level",
 						Required: false,
-						EnvVar:   "LOGLEVEL",
+						EnvVars:  []string{"LOGLEVEL"},
 						Value:    "info",
 						Usage:    "Bridge log level",
 					},
@@ -185,13 +188,13 @@ For all the example cases, see: https://docs.kairos.io .
 						Name:     "qr-code-snapshot",
 						Required: false,
 						Usage:    "Bool to take a local snapshot instead of reading from an image file for recovery",
-						EnvVar:   "QR_CODE_SNAPSHOT",
+						EnvVars:  []string{"QR_CODE_SNAPSHOT"},
 					},
 					&cli.StringFlag{
 						Name:     "qr-code-image",
 						Usage:    "Path to an image containing a valid QR code for recovery mode",
 						Required: false,
-						EnvVar:   "QR_CODE_IMAGE",
+						EnvVars:  []string{"QR_CODE_IMAGE"},
 					},
 					&cli.StringFlag{
 						Name:  "api",
@@ -199,21 +202,21 @@ For all the example cases, see: https://docs.kairos.io .
 						Usage: "Listening API url",
 					},
 					&cli.BoolFlag{
-						Name:   "dhcp",
-						EnvVar: "DHCP",
-						Usage:  "Enable DHCP",
+						Name:    "dhcp",
+						EnvVars: []string{"DHCP"},
+						Usage:   "Enable DHCP",
 					},
 					&cli.StringFlag{
-						Value:  "10.1.0.254/24",
-						Name:   "address",
-						EnvVar: "ADDRESS",
-						Usage:  "Specify an address for the bridge",
+						Value:   "10.1.0.254/24",
+						Name:    "address",
+						EnvVars: []string{"ADDRESS"},
+						Usage:   "Specify an address for the bridge",
 					},
 					&cli.StringFlag{
-						Value:  "/tmp/kairos",
-						Name:   "lease-dir",
-						EnvVar: "lease-dir",
-						Usage:  "DHCP Lease directory",
+						Value:   "/tmp/kairos",
+						Name:    "lease-dir",
+						EnvVars: []string{"lease-dir"},
+						Usage:   "DHCP Lease directory",
 					},
 				},
 				Action: bridge,
@@ -246,7 +249,7 @@ For all the example cases, see: https://docs.kairos.io .
 			{
 				Name:  "role",
 				Usage: "Set or list node roles",
-				Subcommands: []cli.Command{
+				Subcommands: []*cli.Command{
 					{
 						Flags:     networkAPI,
 						Name:      "set",
@@ -266,7 +269,7 @@ For all the example cases, see: https://docs.kairos.io .
 							cc := service.NewClient(
 								c.String("network-id"),
 								edgeVPNClient.NewClient(edgeVPNClient.WithHost(c.String("api"))))
-							return cc.Set("role", c.Args()[0], c.Args()[1])
+							return cc.Set("role", c.Args().Get(0), c.Args().Get(1))
 						},
 					},
 					{
@@ -301,9 +304,8 @@ For all the example cases, see: https://docs.kairos.io .
 
 				Action: func(c *cli.Context) error {
 					l := int(^uint(0) >> 1)
-					args := c.Args()
-					if len(args) > 0 {
-						if i, err := strconv.Atoi(args[0]); err == nil {
+					if c.Args().Present() {
+						if i, err := strconv.Atoi(c.Args().Get(0)); err == nil {
 							l = i
 						}
 					}
@@ -325,9 +327,8 @@ For all the example cases, see: https://docs.kairos.io .
 
 				Action: func(c *cli.Context) error {
 					l := int(^uint(0) >> 1)
-					args := c.Args()
-					if len(args) > 0 {
-						if i, err := strconv.Atoi(args[0]); err == nil {
+					if c.Args().Present() {
+						if i, err := strconv.Atoi(c.Args().Get(0)); err == nil {
 							l = i
 						}
 					}

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -107,8 +107,9 @@ For all the example cases, see: https://docs.kairos.io .
 				ArgsUsage: "Register optionally accepts an image. If nothing is passed will take a screenshot of the screen and try to decode the QR code",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "config",
-						Usage: "Kairos YAML configuration file",
+						Name:     "config",
+						Usage:    "Kairos YAML configuration file",
+						Required: true,
 					},
 					&cli.StringFlag{
 						Name:  "device",


### PR DESCRIPTION
With the upgrade of the cli pkg, making flags required is very simple, it just needs an attribute `required: true`

Fixes https://github.com/kairos-io/kairos/issues/375

:warning: breaking UX change

> In v2 flags must come before args. This is more POSIX-compliant. You may need to update scripts, user documentation, etc.

This means that 

```
provier-kairos command ARG FLAG
```

is no longer valid, but I still think the change is worth it because like the documentation says, the CLI will be more POSIX-compliant