### PR TITLE
Test goreleaser/upgrade to go1.18

### DIFF
--- a/.github/workflows/release_bin.yaml
+++ b/.github/workflows/release_bin.yaml
@@ -2,6 +2,8 @@ name: goreleaser
 
 on:
   push:
+    branches:
+      - 'test-goreleaser/**'
     tags:
       - 'v*'
 
@@ -16,8 +18,15 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
+      - name: (dry-run) GoReleaser
+        if: startsWith(github.ref_name, 'test-goreleaser')
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --skip-validate --skip-publish
       - name: Run GoReleaser
+        if: startsWith(github.ref_name, 'test-goreleaser') != true
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest


### PR DESCRIPTION
- upgrade go version to 1.18 to fix https://github.com/kairos-io/kairos/issues/589
- add a mechanism to test gorelease by prefixing your branch with `test-goreleaser/`