### PR TITLE
Exclude `.img` images from upgrades

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -272,9 +272,9 @@ linux-bench-scan:
 # Generic targets
 # usage e.g. ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/qrcode.yaml
 datasource-iso:
-  ARG ELEMENTAL_IMAGE
+  ARG OSBUILDER_IMAGE
   ARG CLOUD_CONFIG
-  FROM $ELEMENTAL_IMAGE
+  FROM $OSBUILDER_IMAGE
   RUN zypper in -y mkisofs
   WORKDIR /build
   RUN touch meta-data

--- a/internal/provider/upgrade.go
+++ b/internal/provider/upgrade.go
@@ -27,7 +27,7 @@ func ListVersions(e *pluggable.Event) pluggable.EventResponse {
 	displayTags := []string{}
 
 	for _, t := range tags {
-		if strings.Contains(t, "k3s") {
+		if strings.Contains(t, "k3s") && !strings.Contains(t, ".img") {
 			displayTags = append(displayTags, t)
 		}
 	}

--- a/tests/provider_upgrade_test.go
+++ b/tests/provider_upgrade_test.go
@@ -4,10 +4,10 @@ package mos_test
 import (
 	"encoding/json"
 
-	. "github.com/spectrocloud/peg/matcher"
 	"github.com/mudler/go-pluggable"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/spectrocloud/peg/matcher"
 	"golang.org/x/mod/semver"
 )
 
@@ -23,7 +23,7 @@ var _ = Describe("provider upgrade test", Label("provider-upgrade"), func() {
 	})
 
 	Context("agent.available_releases event", func() {
-		It("returns the available versions ordered", func() {
+		It("returns the available versions ordered, excluding '.img' tags", func() {
 			resultStr, _ := Sudo(`echo '{}' | /system/providers/agent-provider-kairos agent.available_releases`)
 
 			var result pluggable.EventResponse
@@ -40,6 +40,10 @@ var _ = Describe("provider upgrade test", Label("provider-upgrade"), func() {
 			copy(sorted, versions)
 
 			semver.Sort(sorted)
+
+			for _, t := range sorted {
+				Expect(t).ToNot(ContainSubstring(".img"))
+			}
 
 			Expect(sorted).To(Equal(versions))
 		})


### PR DESCRIPTION
and fix renamed Earthly ARG

Fixes https://github.com/kairos-io/kairos/issues/598

Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>