### PR TITLE
:warning: Add tumbleweed flavor

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -16,8 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - flavor: "opensuse-arm-rpi"
+          - flavor: "opensuse-leap-arm-rpi"
             model: rpi64
+          # tumbleweed disabled until there is a new release of core images.
+          # otherwise it tries to pull from quay.io/kairos/core-${FLAVOR}:${CORE_VERSION} but there is no tumbleweed with CORE_VERSION
+          #- flavor: "opensuse-tumbleweed-arm-rpi"
+          #  model: rpi64
           - flavor: "alpine-arm-rpi"
             model: rpi64
     steps:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -19,8 +19,10 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         - flavor: "opensuse"
-         #- flavor: "tumbleweed"
+         - flavor: "opensuse-leap"
+         # tumbleweed disabled until there is a new release of core images.
+         # otherwise it tries to pull from quay.io/kairos/core-${FLAVOR}:${CORE_VERSION} but there is no tumbleweed with CORE_VERSION
+         # - flavor: "opensuse-tumbleweed"
          #- flavor: "fedora"
          #- flavor: "ubuntu"
          - flavor: "alpine-opensuse-leap"
@@ -162,7 +164,7 @@ jobs:
       fail-fast: true
       matrix:
        include:
-         - flavor: "opensuse"
+         - flavor: "opensuse-leap"
            node: "A" # Arbitrary field
          - flavor: "alpine-opensuse-leap"
            node: "B" # Arbitrary field
@@ -210,9 +212,9 @@ jobs:
       fail-fast: true
       matrix:
        include:
-         - flavor: "opensuse"
+         - flavor: "opensuse-leap"
            node: "A" # Arbitrary field
-         - flavor: "opensuse"
+         - flavor: "opensuse-leap"
            node: "B"
 #         - flavor: "alpine"
 #           node: "C"
@@ -325,7 +327,7 @@ jobs:
       matrix:
        include:
          - flavor: "alpine-opensuse-leap"
-         - flavor: "opensuse"
+         - flavor: "opensuse-leap"
     steps:
     - uses: robinraju/release-downloader@v1.7
       with:     
@@ -433,7 +435,7 @@ jobs:
        include:
          - flavor: "alpine-opensuse-leap"
            node: "A" # Arbitrary field
-         - flavor: "opensuse"
+         - flavor: "opensuse-leap"
            node: "B"
 #         - flavor: "alpine"
 #           node: "C"

--- a/Earthfile
+++ b/Earthfile
@@ -4,7 +4,7 @@ IMPORT github.com/kairos-io/kairos
 
 FROM alpine
 ARG VARIANT=kairos # core, lite, framework
-ARG FLAVOR=opensuse
+ARG FLAVOR=opensuse-leap
 
 ## Versioning
 ARG K3S_VERSION


### PR DESCRIPTION
Based on the new tumbleweed flavor for kairos

Blocked until https://github.com/kairos-io/kairos/pull/710 gets in and pushes the new flavor

 - [x] copy all artifacts from quay.io/kairos/kairos-opensuse to quay.io/kairos/kairos-opensuse-leap
 - [x] copy all signatures from quay.io/kairos/kairos-opensuse to quay.io/kairos/kairos-opensuse-leap
 - [x] copy all artifacts from quay.io/kairos/kairos-opensuse-arm-rpi to quay.io/kairos/kairos-opensuse-leap-arm-rpi
 - [x] copy all artifacts from quay.io/kairos/kairos-opensuse-arm-rpi to quay.io/kairos/kairos-opensuse-leap-arm-rpi

Signed-off-by: Itxaka <itxaka@spectrocloud.com>