### PR TITLE
Adds newer flavors to the bump_k3s_versions script

### DIFF
--- a/.github/bump_k3s_versions.sh
+++ b/.github/bump_k3s_versions.sh
@@ -14,8 +14,8 @@ for index in "${!versions[@]}" ; do
 done
 versions="${versions[@]}"
 
-amd64_flavor=("opensuse" "alpine-ubuntu" "alpine-opensuse-leap" "ubuntu" "ubuntu-20-lts" "ubuntu-22-lts" "fedora" "debian")
-arm64_flavor=("opensuse-arm-rpi" "alpine-arm-rpi")
+amd64_flavor=("opensuse-leap" "opensuse-tumbleweed" "alpine-ubuntu" "alpine-opensuse-leap" "ubuntu" "ubuntu-20-lts" "ubuntu-22-lts" "fedora" "debian")
+arm64_flavor=("opensuse-leap-arm-rpi" "opensuse-tumbleweed-arm-rpi" "alpine-arm-rpi")
 arm64_models=("rpi64")
 releases="[]"
 releases_arm="[]"

--- a/releases-arm.json
+++ b/releases-arm.json
@@ -1,6 +1,11 @@
 [
   {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-leap-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.20.15+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.20.15+k3s1"
   },
@@ -10,7 +15,12 @@
     "k3s_version": "v1.20.15+k3s1"
   },
   {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-leap-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.21.14+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.21.14+k3s1"
   },
@@ -20,7 +30,12 @@
     "k3s_version": "v1.21.14+k3s1"
   },
   {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-leap-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.22.17+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.22.17+k3s1"
   },
@@ -30,7 +45,12 @@
     "k3s_version": "v1.22.17+k3s1"
   },
   {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-leap-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.23.16+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.23.16+k3s1"
   },
@@ -40,7 +60,12 @@
     "k3s_version": "v1.23.16+k3s1"
   },
   {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-leap-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.24.10+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.24.10+k3s1"
   },
@@ -50,17 +75,12 @@
     "k3s_version": "v1.24.10+k3s1"
   },
   {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-leap-arm-rpi",
     "model": "rpi64",
-    "k3s_version": "v1.25.5+k3s2"
+    "k3s_version": "v1.25.6+k3s1"
   },
   {
-    "flavor": "alpine-arm-rpi",
-    "model": "rpi64",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-tumbleweed-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.25.6+k3s1"
   },
@@ -70,7 +90,12 @@
     "k3s_version": "v1.25.6+k3s1"
   },
   {
-    "flavor": "opensuse-arm-rpi",
+    "flavor": "opensuse-leap-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.26.1+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.26.1+k3s1"
   },

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,10 @@
 [
   {
-    "flavor": "opensuse",
+    "flavor": "opensuse-leap",
+    "k3s_version": "v1.20.15+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed",
     "k3s_version": "v1.20.15+k3s1"
   },
   {
@@ -32,7 +36,11 @@
     "k3s_version": "v1.20.15+k3s1"
   },
   {
-    "flavor": "opensuse",
+    "flavor": "opensuse-leap",
+    "k3s_version": "v1.21.14+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed",
     "k3s_version": "v1.21.14+k3s1"
   },
   {
@@ -64,7 +72,11 @@
     "k3s_version": "v1.21.14+k3s1"
   },
   {
-    "flavor": "opensuse",
+    "flavor": "opensuse-leap",
+    "k3s_version": "v1.22.17+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed",
     "k3s_version": "v1.22.17+k3s1"
   },
   {
@@ -96,7 +108,11 @@
     "k3s_version": "v1.22.17+k3s1"
   },
   {
-    "flavor": "opensuse",
+    "flavor": "opensuse-leap",
+    "k3s_version": "v1.23.16+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed",
     "k3s_version": "v1.23.16+k3s1"
   },
   {
@@ -128,7 +144,11 @@
     "k3s_version": "v1.23.16+k3s1"
   },
   {
-    "flavor": "opensuse",
+    "flavor": "opensuse-leap",
+    "k3s_version": "v1.24.10+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed",
     "k3s_version": "v1.24.10+k3s1"
   },
   {
@@ -160,39 +180,11 @@
     "k3s_version": "v1.24.10+k3s1"
   },
   {
-    "flavor": "opensuse",
-    "k3s_version": "v1.25.5+k3s2"
+    "flavor": "opensuse-leap",
+    "k3s_version": "v1.25.6+k3s1"
   },
   {
-    "flavor": "alpine-ubuntu",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "alpine-opensuse-leap",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "ubuntu",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "ubuntu-20-lts",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "ubuntu-22-lts",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "fedora",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "debian",
-    "k3s_version": "v1.25.5+k3s2"
-  },
-  {
-    "flavor": "opensuse",
+    "flavor": "opensuse-tumbleweed",
     "k3s_version": "v1.25.6+k3s1"
   },
   {
@@ -224,7 +216,11 @@
     "k3s_version": "v1.25.6+k3s1"
   },
   {
-    "flavor": "opensuse",
+    "flavor": "opensuse-leap",
+    "k3s_version": "v1.26.1+k3s1"
+  },
+  {
+    "flavor": "opensuse-tumbleweed",
     "k3s_version": "v1.26.1+k3s1"
   },
   {


### PR DESCRIPTION
I forgot this script so on 1.5.0 nothing opensuse related was build and published due to the name change

Signed-off-by: Itxaka <itxaka@spectrocloud.com>