### PR TITLE
:bug: Remove debian specific block

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -29,6 +29,7 @@ jobs:
           - flavor: "alpine-ubuntu"
           - flavor: "ubuntu"
           - flavor: "rockylinux"
+          - flavor: "debian"
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/Earthfile
+++ b/Earthfile
@@ -112,13 +112,11 @@ docker:
     
     COPY repository.yaml /etc/luet/luet.yaml
 
-    IF [ "$FLAVOR" = "debian" ]
-      RUN apt-get install -y nohang
-    ELSE IF [ "$FLAVOR" = "opensuse-leap" ] || [ "$FLAVOR" = "opensuse-leap-arm-rpi" ]
+    IF [ "$FLAVOR" = "opensuse-leap" ] || [ "$FLAVOR" = "opensuse-leap-arm-rpi" ]
       RUN zypper ar -G https://download.opensuse.org/repositories/utilities/15.4/utilities.repo && zypper ref && zypper in -y nohang
     ELSE IF [ "$FLAVOR" = "opensuse-tumbleweed" ] || [ "$FLAVOR" = "opensuse-tumbleweed-arm-rpi" ]
       RUN zypper ar -G https://download.opensuse.org/repositories/utilities/openSUSE_Factory/utilities.repo && zypper ref && zypper in -y nohang
-    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ] || [ "$FLAVOR" = "ubuntu-22-lts" ]
+    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ] || [ "$FLAVOR" = "ubuntu-22-lts" ] || [ "$FLAVOR" = "debian" ]
       RUN apt-get update && apt-get install -y nohang
     END
 


### PR DESCRIPTION
We didn't called `apt-get update` before installing nohang, so it wasn't found in the repo. I've also added the `debian` flavor to the build job of the CI so we can spot those issues before.

Fixes: https://github.com/kairos-io/kairos/issues/970