### PR TITLE
:robot: Version SBOM after TAG

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -231,13 +231,13 @@ syft:
 image-sbom:
     FROM +docker
     WORKDIR /build
-    ARG VERSION
+    ARG TAG
     ARG FLAVOR
     ARG VARIANT
     COPY +syft/syft /usr/bin/syft
     RUN syft / -o json=sbom.syft.json -o spdx-json=sbom.spdx.json
-    SAVE ARTIFACT /build/sbom.syft.json sbom.syft.json AS LOCAL build/${VARIANT}-${FLAVOR}-${VERSION}-sbom.syft.json
-    SAVE ARTIFACT /build/sbom.spdx.json sbom.spdx.json AS LOCAL build/${VARIANT}-${FLAVOR}-${VERSION}-sbom.spdx.json
+    SAVE ARTIFACT /build/sbom.syft.json sbom.syft.json AS LOCAL build/${VARIANT}-${FLAVOR}-${TAG}-sbom.syft.json
+    SAVE ARTIFACT /build/sbom.spdx.json sbom.spdx.json AS LOCAL build/${VARIANT}-${FLAVOR}-${TAG}-sbom.spdx.json
 
 ipxe-iso:
     FROM ubuntu


### PR DESCRIPTION
We can't use VERSION, as we have a bigger matrix consisting of k3s versions too. that lead to each job to replace the sbom of another one:

```
Run softprops/action-gh-release@v1
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1-initrd...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1-ipxe-usb.img.ipxe...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1-ipxe.iso.ipxe...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1-kernel...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1.ipxe...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1.iso...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1.iso.sha256...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-k3sv1.21.14+k3s1.squashfs...
♻️ Deleting previously uploaded asset kairos-alpine-opensuse-leap-v2.0.0-rc3-sbom.spdx.json...
♻️ Deleting previously uploaded asset kairos-alpine-opensuse-leap-v2.0.0-rc3-sbom.syft.json...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-sbom.spdx.json...
⬆️ Uploading kairos-alpine-opensuse-leap-v2.0.0-rc3-sbom.syft.json...
Error: Failed to upload release asset kairos-alpine-opensuse-leap-v2.0.0-rc3-sbom.spdx.json. received status code 404
```