### PR TITLE
:robot: Release arm64 generic artifacts

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         flavor:
-          - "opensuse-leap"
+          - "opensuse-leap-arm-generic"
     steps:
       - uses: actions/checkout@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -110,17 +110,15 @@ jobs:
       - name: Build  🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
-          IMAGE: "quay.io/kairos/kairos-${{ matrix.flavor }}-arm-generic"
-          BASE_IMAGE: "quay.io/kairos/core-${{ matrix.flavor }}-arm-generic"
-          TAG: "latest"
+          IMAGE: "quay.io/kairos/kairos-${{ matrix.flavor }}"
+          TAG: "master"
         run: |
-          earthly --platform=linux/arm64 +docker --BASE_IMAGE="$BASE_IMAGE" --IMAGE="$IMAGE:$TAG" --FLAVOR=$FLAVOR
-          earthly --platform=linux/arm64 +iso --IMAGE="$IMAGE:$TAG" --FLAVOR=${{ matrix.flavor }}
+          earthly -P +all-arm-generic --IMAGE="$IMAGE:$TAG" --FLAVOR=${{ matrix.flavor }} --CORE_VERSION=master
       - name: Push to quay
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
-          IMAGE: "quay.io/kairos/kairos-${{ matrix.flavor }}-arm-generic"
-          TAG: "latest"
+          IMAGE: "quay.io/kairos/kairos-${{ matrix.flavor }}"
+          TAG: "master"
         run: |
           docker push "$IMAGE:$TAG"
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -87,3 +87,44 @@ jobs:
           sudo -E docker load -i image.tar
           sudo -E docker push "$IMAGE"
           sudo rm -rf build/IMAGE build/VERSION
+
+  image_and_iso_arm64_generic:
+    needs:
+      - get-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - "opensuse-leap-arm-generic"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install earthly
+        uses: Luet-lab/luet-install-action@v1
+        with:
+          repository: quay.io/kairos/packages
+          packages: utils/earthly
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Build  🔧
+        run: |
+          K3S_LATEST=$(curl -s https://update.k3s.io/v1-release/channels | jq -rc '[ .data[] | select(.type == "channel") | select(.name | test("testing") | not) | .latest ] | unique | .[-1]')
+          earthly -P +all-arm-generic --FLAVOR=${{ matrix.flavor }} --K3S_VERSION=$K3S_LATEST
+          sudo mv build release
+      - name: Push to quay
+        run: |
+          IMAGE=$(cat release/IMAGE)
+          docker push "$IMAGE"
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            release/*

--- a/Earthfile
+++ b/Earthfile
@@ -37,6 +37,12 @@ RELEASEVERSION:
     SAVE ARTIFACT VERSION AS LOCAL build/VERSION
     SAVE ARTIFACT IMAGE AS LOCAL build/IMAGE
 
+all-arm-generic:
+  BUILD --platform=linux/arm64 +docker
+  BUILD --platform=linux/arm64 +image-sbom
+  BUILD --platform=linux/arm64 +iso
+  DO +RELEASEVERSION
+
 all:
   BUILD +docker
   BUILD +image-sbom


### PR DESCRIPTION
Builds and releases oci artifacts and ISOs for release pipelines.

Also reworks a bit the master pipeline for arm generic to push to the master tag instead of latest.

Also generates sboms as part of both pipelines