### PR TITLE
:penguin: Add ubuntu versions to the arm releases matrix

### DIFF
--- a/releases-arm.json
+++ b/releases-arm.json
@@ -15,6 +15,21 @@
     "k3s_version": "v1.20.15+k3s1"
   },
   {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.20.15+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.20.15+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.20.15+k3s1"
+  },
+  {
     "flavor": "opensuse-leap-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.21.14+k3s1"
@@ -30,6 +45,21 @@
     "k3s_version": "v1.21.14+k3s1"
   },
   {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.21.14+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.21.14+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.21.14+k3s1"
+  },
+  {
     "flavor": "opensuse-leap-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.22.17+k3s1"
@@ -41,6 +71,21 @@
   },
   {
     "flavor": "alpine-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.22.17+k3s1"
+  },
+  {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.22.17+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.22.17+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.22.17+k3s1"
   },
@@ -56,6 +101,21 @@
   },
   {
     "flavor": "alpine-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.23.17+k3s1"
+  },
+  {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.23.17+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.23.17+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.23.17+k3s1"
   },
@@ -71,6 +131,21 @@
   },
   {
     "flavor": "alpine-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.24.13+k3s1"
+  },
+  {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.24.13+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.24.13+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.24.13+k3s1"
   },
@@ -86,6 +161,21 @@
   },
   {
     "flavor": "alpine-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.25.9+k3s1"
+  },
+  {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.25.9+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.25.9+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.25.9+k3s1"
   },
@@ -101,6 +191,21 @@
   },
   {
     "flavor": "alpine-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.26.3+k3s1"
+  },
+  {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.26.3+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.26.3+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.26.3+k3s1"
   },
@@ -116,6 +221,21 @@
   },
   {
     "flavor": "alpine-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.26.4+k3s1"
+  },
+  {
+    "flavor": "ubuntu-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.26.4+k3s1"
+  },
+  {
+    "flavor": "ubuntu-22-lts-arm-rpi",
+    "model": "rpi64",
+    "k3s_version": "v1.26.4+k3s1"
+  },
+  {
+    "flavor": "ubuntu-20-lts-arm-rpi",
     "model": "rpi64",
     "k3s_version": "v1.26.4+k3s1"
   }


### PR DESCRIPTION
I missed the fact that the releases were a different source than the build

Relates to kairos-io/kairos#1439