### PR TITLE
Bump osbuilder version

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -21,7 +21,8 @@ ARG IMAGE=${BASE_REPO}/${VARIANT}-${FLAVOR}:$TAG
 ARG BASE_IMAGE=quay.io/kairos/core-${FLAVOR}:${CORE_VERSION}
 ARG ISO_NAME=${VARIANT}-${FLAVOR}-${VERSION}-k3s${K3S_VERSION}
 # renovate: datasource=docker depName=quay.io/kairos/osbuilder-tools versioning=semver-coerced
-ARG OSBUILDER_IMAGE=quay.io/kairos/osbuilder-tools:v0.6.7
+ARG OSBUILDER_VERSION=v0.7.4
+ARG OSBUILDER_IMAGE=quay.io/kairos/osbuilder-tools:$OSBUILDER_VERSION
 
 ## External deps pinned versions
 ARG LUET_VERSION=0.33.0


### PR DESCRIPTION
A bunch has happened between 0.6.7 and 0.7.4, we probably want the latest since it brings the lvm support and other things