### PR TITLE
Don't add spaces to artifact names

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,20 +33,11 @@ source:
 archives:
   # Default template uses underscores instead of -
   - name_template: >-
-      kairos-cli-
-      {{ .Tag }}-
-      {{ .Os }}-
-      {{ .Arch }}
-      {{ if .Arm }}v{{ .Arm }}{{ end }}
+  - name_template: "kairos-cli-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     id: kairos-id
     builds:
       - "kairos-id"
-  - name_template: >-
-      kairosctl-
-      {{ .Tag }}-
-      {{ .Os }}-
-      {{ .Arch }}
-      {{ if .Arm }}v{{ .Arm }}{{ end }}
+  - name_template: "kairosctl-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     id: kairosctl
     builds:
       - "kairosctl"


### PR DESCRIPTION
because somehow the end up as `.` in the final artifact in Github releases (probably because [Github converts spaces to dots](https://github.com/cli/cli/issues/7024#issue-1592370641)).

Fixes https://github.com/kairos-io/kairos/issues/1520