### PR TITLE
fix: bump go.mod path to v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 # Make sure to check the documentation at http://goreleaser.com
 builds:
   - ldflags:
-      - -w -s -X "github.com/kairos-io/provider-kairos/internal/cli.VERSION={{.Env.VERSION}}"
+      - -w -s -X "github.com/kairos-io/provider-kairos/v2/internal/cli.VERSION={{.Env.VERSION}}"
     env:
       - CGO_ENABLED=0
     goos:
@@ -9,7 +9,7 @@ builds:
       - windows
     goarch:
       - amd64
-      - 386
+      - '386'
     main: ./
     id: "kairos-cli"
     binary: "kairos-cli"
@@ -22,7 +22,7 @@ builds:
       - windows
     goarch:
       - amd64
-      - 386
+      - '386'
     main: ./cli/kairosctl
     id: "kairosctl"
     binary: "kairosctl"

--- a/Earthfile
+++ b/Earthfile
@@ -93,7 +93,7 @@ BUILD_GOLANG:
     COPY . ./
     ARG CGO_ENABLED
     ARG VERSION
-    ARG LDFLAGS="-s -w -X 'github.com/kairos-io/provider-kairos/internal/cli.VERSION=$VERSION'"
+    ARG LDFLAGS="-s -w -X 'github.com/kairos-io/provider-kairos/v2/internal/cli.VERSION=$VERSION'"
     ARG BIN
     ARG SRC
     ENV CGO_ENABLED=${CGO_ENABLED}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <img src="https://img.shields.io/badge/licence-APL2-brightgreen"
          alt="license">
   </a>
-  <a href="https://github.com/kairos-io/provider-kairos/issues"><img src="https://img.shields.io/github/issues/kairos-io/provider-kairos"></a>
+  <a href="https://github.com/kairos-io/provider-kairos/v2/issues"><img src="https://img.shields.io/github/issues/kairos-io/provider-kairos"></a>
   <a href="https://kairos.io/docs/" target=_blank> <img src="https://img.shields.io/badge/Documentation-blue"
          alt="docs"></a>
   <img src="https://img.shields.io/badge/made%20with-Go-blue">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <img src="https://img.shields.io/badge/licence-APL2-brightgreen"
          alt="license">
   </a>
-  <a href="https://github.com/kairos-io/provider-kairos/v2/issues"><img src="https://img.shields.io/github/issues/kairos-io/provider-kairos"></a>
+  <a href="https://github.com/kairos-io/provider-kairos/issues"><img src="https://img.shields.io/github/issues/kairos-io/provider-kairos"></a>
   <a href="https://kairos.io/docs/" target=_blank> <img src="https://img.shields.io/badge/Documentation-blue"
          alt="docs"></a>
   <img src="https://img.shields.io/badge/made%20with-Go-blue">

--- a/cli/kairosctl/main.go
+++ b/cli/kairosctl/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/kairos-io/kairos-sdk/bus"
-	iCli "github.com/kairos-io/provider-kairos/internal/cli"
-	"github.com/kairos-io/provider-kairos/internal/provider"
+	iCli "github.com/kairos-io/provider-kairos/v2/internal/cli"
+	"github.com/kairos-io/provider-kairos/v2/internal/provider"
 	"github.com/urfave/cli/v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kairos-io/provider-kairos
+module github.com/kairos-io/provider-kairos/v2
 
 go 1.18
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/kairos-io/kairos/v2/pkg/config"
-	. "github.com/kairos-io/provider-kairos/internal/cli"
+	. "github.com/kairos-io/provider-kairos/v2/internal/cli"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"

--- a/internal/cli/recovery_darwin.go
+++ b/internal/cli/recovery_darwin.go
@@ -1,0 +1,8 @@
+package cli
+
+import (
+	"os"
+)
+
+func setWinsize(f *os.File, w, h int) {
+}

--- a/internal/cli/rotate.go
+++ b/internal/cli/rotate.go
@@ -10,9 +10,9 @@ import (
 	"github.com/kairos-io/kairos-sdk/unstructured"
 	"github.com/kairos-io/kairos/v2/pkg/config"
 	"github.com/kairos-io/kairos/v2/pkg/config/collector"
-	"github.com/kairos-io/provider-kairos/internal/provider"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
-	"github.com/kairos-io/provider-kairos/internal/services"
+	"github.com/kairos-io/provider-kairos/v2/internal/provider"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
+	"github.com/kairos-io/provider-kairos/v2/internal/services"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -2,9 +2,10 @@ package cli
 
 import (
 	"fmt"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
 	"os"
 	"strconv"
+
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 
 	"github.com/kairos-io/kairos-sdk/schema"
 	"github.com/mudler/edgevpn/pkg/node"
@@ -13,7 +14,7 @@ import (
 )
 
 // do not edit version here, it is set by LDFLAGS
-// -X 'github.com/kairos-io/provider-kairos/internal/cli.VERSION=$VERSION'
+// -X 'github.com/kairos-io/provider-kairos/v2/internal/cli.VERSION=$VERSION'
 // see Earthlfile.
 var VERSION = "0.0.0"
 var Author = "Ettore Di Giacinto"

--- a/internal/provider/bootstrap.go
+++ b/internal/provider/bootstrap.go
@@ -15,11 +15,11 @@ import (
 	"github.com/kairos-io/kairos-sdk/machine/openrc"
 	"github.com/kairos-io/kairos-sdk/machine/systemd"
 	"github.com/kairos-io/kairos-sdk/utils"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
-	"github.com/kairos-io/provider-kairos/internal/role"
-	p2p "github.com/kairos-io/provider-kairos/internal/role/p2p"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
+	"github.com/kairos-io/provider-kairos/v2/internal/role"
+	p2p "github.com/kairos-io/provider-kairos/v2/internal/role/p2p"
 
-	"github.com/kairos-io/provider-kairos/internal/services"
+	"github.com/kairos-io/provider-kairos/v2/internal/services"
 
 	"github.com/kairos-io/kairos/v2/pkg/config"
 	"github.com/mudler/edgevpn/api/client/service"

--- a/internal/provider/bootstrap_test.go
+++ b/internal/provider/bootstrap_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/kairos-io/kairos-sdk/bus"
 
-	. "github.com/kairos-io/provider-kairos/internal/provider"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
+	. "github.com/kairos-io/provider-kairos/v2/internal/provider"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 	"github.com/mudler/go-pluggable"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/provider/challenge.go
+++ b/internal/provider/challenge.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kairos-io/kairos-sdk/bus"
 
 	"github.com/kairos-io/kairos/v2/pkg/config"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 
 	"github.com/kairos-io/go-nodepair"
 	"github.com/mudler/go-pluggable"

--- a/internal/provider/challenge_test.go
+++ b/internal/provider/challenge_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/kairos-io/kairos-sdk/bus"
 
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 
-	. "github.com/kairos-io/provider-kairos/internal/provider"
+	. "github.com/kairos-io/provider-kairos/v2/internal/provider"
 	"github.com/mudler/go-pluggable"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/internal/provider/p2p.go
+++ b/internal/provider/p2p.go
@@ -7,13 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kairos-io/provider-kairos/internal/provider/assets"
+	"github.com/kairos-io/provider-kairos/v2/internal/provider/assets"
 
 	"github.com/kairos-io/kairos-sdk/machine"
 	"github.com/kairos-io/kairos-sdk/machine/systemd"
 	"github.com/kairos-io/kairos-sdk/utils"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
-	"github.com/kairos-io/provider-kairos/internal/services"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
+	"github.com/kairos-io/provider-kairos/v2/internal/services"
 	"gopkg.in/yaml.v3"
 
 	yip "github.com/mudler/yip/pkg/schema"

--- a/internal/role/auto.go
+++ b/internal/role/auto.go
@@ -3,7 +3,7 @@ package role
 import (
 	"github.com/kairos-io/kairos/v2/pkg/config"
 
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 	utils "github.com/mudler/edgevpn/pkg/utils"
 
 	service "github.com/mudler/edgevpn/api/client/service"

--- a/internal/role/p2p/common.go
+++ b/internal/role/p2p/common.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 )
 
 func guessInterface(pconfig *providerConfig.Config) string {

--- a/internal/role/p2p/kubevip.go
+++ b/internal/role/p2p/kubevip.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/kairos-io/kairos-sdk/utils"
-	"github.com/kairos-io/provider-kairos/internal/assets"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
+	"github.com/kairos-io/provider-kairos/v2/internal/assets"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 )
 
 func generateKubeVIP(iface, ip string, args []string) (string, error) {

--- a/internal/role/p2p/master.go
+++ b/internal/role/p2p/master.go
@@ -11,8 +11,8 @@ import (
 	"github.com/kairos-io/kairos-sdk/machine"
 	"github.com/kairos-io/kairos-sdk/utils"
 	"github.com/kairos-io/kairos/v2/pkg/config"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
-	"github.com/kairos-io/provider-kairos/internal/role"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
+	"github.com/kairos-io/provider-kairos/v2/internal/role"
 
 	service "github.com/mudler/edgevpn/api/client/service"
 )

--- a/internal/role/p2p/worker.go
+++ b/internal/role/p2p/worker.go
@@ -9,8 +9,8 @@ import (
 	"github.com/kairos-io/kairos-sdk/utils"
 	"github.com/kairos-io/kairos/v2/pkg/config"
 
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
-	"github.com/kairos-io/provider-kairos/internal/role"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
+	"github.com/kairos-io/provider-kairos/v2/internal/role"
 	service "github.com/mudler/edgevpn/api/client/service"
 )
 

--- a/internal/role/schedule.go
+++ b/internal/role/schedule.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/kairos-io/kairos/v2/pkg/config"
-	providerConfig "github.com/kairos-io/provider-kairos/internal/provider/config"
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
 	"github.com/mudler/edgevpn/api/client/service"
 	"github.com/samber/lo"
 )

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/kairos-io/kairos-sdk/bus"
-	"github.com/kairos-io/provider-kairos/internal/cli"
-	"github.com/kairos-io/provider-kairos/internal/provider"
+	"github.com/kairos-io/provider-kairos/v2/internal/cli"
+	"github.com/kairos-io/provider-kairos/v2/internal/provider"
 )
 
 func checkErr(err error) {

--- a/tests/e2e/ha_test.go
+++ b/tests/e2e/ha_test.go
@@ -157,7 +157,7 @@ var _ = Describe("kairos decentralized k8s test", Label("proxmox-ha-test"), func
 			VMIDS = append(VMIDS, startVMS([]byte(genConfig(freeIP, pubkey, networkToken, true, false, false, true)), 4)...)
 
 			By("Waiting for HA control-plane to be available", func() {
-				ping(freeIP)
+				ping(freeIP, ControlVM)
 			})
 
 			Eventually(func() string {
@@ -196,7 +196,7 @@ var _ = Describe("kairos decentralized k8s test", Label("proxmox-ha-test"), func
 
 			// 10.1.0.1 will be our IP, and DHCP will assign then 10.1.0.2 to one of the nodes of the cluster.
 			By("Waiting for HA control-plane to be available", func() {
-				ping("10.1.0.2")
+				ping("10.1.0.2", ControlVM)
 			})
 
 			Eventually(func() string {

--- a/tests/e2e/proxmox.go
+++ b/tests/e2e/proxmox.go
@@ -88,6 +88,10 @@ func uploadCloudInitISO(isoname string, cc []byte, storage *proxmox.Storage) err
 	}
 
 	tup, err := storage.Upload("iso", filepath.Join(temp, isoname))
+	if err != nil {
+		return err
+	}
+
 	return tup.WaitFor(300)
 }
 
@@ -161,6 +165,9 @@ func getNode() (*proxmox.Node, *proxmox.Client, error) {
 	fmt.Println(version.Release) // 6.3
 
 	statuses, err := client.Nodes()
+	if err != nil {
+		return nil, nil, err
+	}
 
 	for _, st := range statuses {
 		fmt.Println(st.Node)
@@ -227,7 +234,7 @@ EOF`)
 
 }
 
-func ping(ip string) {
+func ping(ip string, ControlVM *SSHConn) {
 	EventuallyWithOffset(1, func() string {
 		out, err := ControlVM.Command(fmt.Sprintf("ping %s -c 3", ip))
 		if err != nil {

--- a/tests/e2e/proxmox.go
+++ b/tests/e2e/proxmox.go
@@ -18,8 +18,10 @@ import (
 	"github.com/luthermonson/go-proxmox"
 )
 
+var randGen *rand.Rand
+
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -27,7 +29,7 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 func RandStringRunes(n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[randGen.Intn(len(letterRunes))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
The path in `go.mod` should be ended in `/v2` suffix, as per [go.mod module version numbers](https://go.dev/doc/modules/version-numbers).