### PR TITLE
:robot: Build only non framework flavors

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -19,9 +19,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           git fetch --prune --unshallow
+          sudo apt update && sudo apt install -y jq
       - id: set-matrix
         run: |
-          content=`curl https://raw.githubusercontent.com/kairos-io/kairos/master/.github/flavors.json`
+          content=`curl https://raw.githubusercontent.com/kairos-io/kairos/master/.github/flavors.json | jq 'map(select(.frameworkonly != "true"))'`
           # the following lines are only required for multi line json
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"


### PR DESCRIPTION
We now have some flavors upstream under kairos which only provide framework images, so we cant build those as part of the normal workflow.

This basically copies the fix from Dimitris in the kairos repo to skip the frameworkonly flavors


Should fix the current CI issue