### PR TITLE
:robot: Add concurrency to all jobs

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: arm-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   get-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   call-workflow:
     uses: kairos-io/linting-composite-action/.github/workflows/reusable-linting.yaml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise we just queue 30 jobs for each if we merge in succession.