### PR TITLE
Add golang information to the --version output 

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -94,11 +94,24 @@ The validate command expects a configuration file as its only argument. Local fi
 		`,
 }
 
+var VersionCMD = cli.Command{
+	Name: "version",
+	Action: func(c *cli.Context) error {
+		printVersion()
+		return nil
+	},
+	Description: "Prints version information of this binary",
+}
+
+func printVersion() {
+	fmt.Printf("version: %s, compiled with: %s\n", VERSION, runtime.Version())
+}
+
 func Start() error {
 	toolName := "kairos"
 
 	cli.VersionPrinter = func(cCtx *cli.Context) {
-		fmt.Printf("version: %s, compiled with: %s\n", VERSION, runtime.Version())
+		printVersion()
 	}
 
 	app := &cli.App{
@@ -163,6 +176,7 @@ For all the example cases, see: https://kairos.io/docs/
 			&CreateConfigCMD,
 			&GenerateTokenCMD,
 			&ValidateSchemaCMD,
+			&VersionCMD,
 		},
 	}
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 
 	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
@@ -95,6 +96,11 @@ The validate command expects a configuration file as its only argument. Local fi
 
 func Start() error {
 	toolName := "kairos"
+
+	cli.VersionPrinter = func(cCtx *cli.Context) {
+		fmt.Printf("version: %s, compiled with: %s\n", VERSION, runtime.Version())
+	}
+
 	app := &cli.App{
 		Name:    toolName,
 		Version: VERSION,


### PR DESCRIPTION
so that we can call it to verify we built a fips version by greping for "boringcrypto" in the output.

Part of: https://github.com/kairos-io/kairos/issues/1609

Will be used here: https://github.com/kairos-io/packages/pull/334