### PR TITLE
:sparkles: Introduce new artifact naming convention

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -246,7 +246,9 @@ arm-image:
   FROM $OSBUILDER_IMAGE
   ARG MODEL=rpi64
   ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-.*//')
-  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${TARGETARCH}-${MODEL}-${VERSION}-k3s${K3S_VERSION}.img
+  # TARGETARCH is not used here because OSBUILDER_IMAGE is not available in arm64. When this changes, then the caller
+  # of this target can simply pass the desired TARGETARCH.
+  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${DISTRO}-arm64-${MODEL}-${VERSION}-k3s${K3S_VERSION}.img
   WORKDIR /build
 
   ENV SIZE="15200"

--- a/Earthfile
+++ b/Earthfile
@@ -31,7 +31,6 @@ ARG GO_VERSION=1.20
 
 ARG MODEL=generic
 ARG TARGETARCH
-ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${TARGETARCH}-${MODEL}-${VERSION}-k3s${K3S_VERSION}
 ARG CGO_ENABLED=0
 
 RELEASEVERSION:
@@ -205,6 +204,12 @@ iso:
     ARG OSBUILDER_IMAGE
     ARG IMG=docker:$IMAGE
     ARG overlay=overlay/files-iso
+    IF [ "$TARGETARCH" = "arm64" ]
+        ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-.*//')
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${TARGETARCH}-${MODEL}-${VERSION}
+    ELSE
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${TARGETARCH}-${MODEL}-${VERSION}
+    END
     FROM $OSBUILDER_IMAGE
     RUN zypper in -y jq docker
     WORKDIR /build
@@ -283,6 +288,12 @@ image-sbom:
     ARG TAG
     ARG FLAVOR
     ARG VARIANT
+    IF [ "$TARGETARCH" = "arm64" ]
+        ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-.*//')
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${TARGETARCH}-${MODEL}-${VERSION}
+    ELSE
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${TARGETARCH}-${MODEL}-${VERSION}
+    END
     COPY +syft/syft /usr/bin/syft
     RUN syft / -o json=sbom.syft.json -o spdx-json=sbom.spdx.json
     SAVE ARTIFACT /build/sbom.syft.json sbom.syft.json AS LOCAL build/${ISO_NAME}-sbom.syft.json

--- a/Earthfile
+++ b/Earthfile
@@ -65,7 +65,7 @@ all-arm:
   ARG SECURITY_SCANS=true
   BUILD --platform=linux/arm64 +docker
   IF [ "$SECURITY_SCANS" = "true" ]
-      BUILD --platform=linux/arm64  +image-sbom
+      BUILD --platform=linux/arm64  +image-sbom --MODEL=rpi64
   END
   BUILD +arm-image --MODEL=rpi64
   DO +RELEASEVERSION
@@ -245,7 +245,8 @@ arm-image:
   ARG COMPRESS_IMG=true
   FROM $OSBUILDER_IMAGE
   ARG MODEL=rpi64
-  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${TARGETARCH}-${MODEL}-${VERSION}-k3s${K3S_VERSION}.img
+  ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-.*//')
+  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${TARGETARCH}-${MODEL}-${VERSION}-k3s${K3S_VERSION}.img
   WORKDIR /build
 
   ENV SIZE="15200"
@@ -288,6 +289,7 @@ image-sbom:
     ARG TAG
     ARG FLAVOR
     ARG VARIANT
+    ARG MODEL
     IF [ "$TARGETARCH" = "arm64" ]
         ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-.*//')
         ARG ISO_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${TARGETARCH}-${MODEL}-${VERSION}


### PR DESCRIPTION
relates to kairos-io/kairos#1109

`earthly +all`

```
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s-initrd
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s.ipxe
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s-ipxe.iso
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s-ipxe-usb.img
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s.iso
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s.iso.sha256
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s-kernel
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s-sbom.spdx.json
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s-sbom.syft.json
kairos-standard-opensuse-leap-amd64-generic-v2.3.1-dirty-k3s.squashfs
```

`earthly +all-arm-generic --FLAVOR=opensuse-leap-arm-generic`

```
kairos-standard-opensuse-leap-arm64-generic-v2.3.1-1-g6a62b88-dirty.iso
kairos-standard-opensuse-leap-arm64-generic-v2.3.1-1-g6a62b88-dirty.iso.sha256
kairos-standard-opensuse-leap-arm64-generic-v2.3.1-1-g6a62b88-dirty-sbom.spdx.json
kairos-standard-opensuse-leap-arm64-generic-v2.3.1-1-g6a62b88-dirty-sbom.syft.json
```

`earthly -P +all-arm --FLAVOR=opensuse-leap-arm-rpi`

```
kairos-standard-opensuse-leap-arm64-rpi64-v2.3.1-3-g4b23855-dirty-k3s.img.xz
kairos-standard-opensuse-leap-arm64-rpi64-v2.3.1-3-g4b23855-dirty-k3s.img.sha256
kairos-standard-opensuse-leap-arm64-rpi64-v2.3.1-3-g4b23855-dirty-sbom.spdx.json
kairos-standard-opensuse-leap-arm64-rpi64-v2.3.1-3-g4b23855-dirty-sbom.syft.json
```