### PR TITLE
Drop elemental calls

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -218,8 +218,6 @@ iso:
     COPY +kairos/kairos/overlay/files-iso/ ./$overlay/
     COPY +docker-rootfs/rootfs /build/image
     RUN /entrypoint.sh --name $ISO_NAME --debug build-iso --date=false dir:/build/image --overlay-iso /build/${overlay} --output /build
-    # See: https://github.com/rancher/elemental-cli/issues/228
-    RUN sha256sum $ISO_NAME.iso > $ISO_NAME.iso.sha256
     SAVE ARTIFACT /build/$ISO_NAME.iso kairos.iso AS LOCAL build/$ISO_NAME.iso
     SAVE ARTIFACT /build/$ISO_NAME.iso.sha256 kairos.iso.sha256 AS LOCAL build/$ISO_NAME.iso.sha256
 

--- a/internal/provider/bootstrap.go
+++ b/internal/provider/bootstrap.go
@@ -54,7 +54,7 @@ func Bootstrap(e *pluggable.Event) pluggable.EventResponse {
 		return pluggable.EventResponse{State: fmt.Sprintf("no kairos or k3s configuration. nothing to do: %s", cfg.Config)}
 	}
 
-	utils.SH("elemental run-stage kairos-agent.bootstrap")    //nolint:errcheck
+	utils.SH("kairos-agent run-stage kairos-agent.bootstrap") //nolint:errcheck
 	bus.RunHookScript("/usr/bin/kairos-agent.bootstrap.hook") //nolint:errcheck
 
 	logLevel := "debug"

--- a/internal/role/p2p/master.go
+++ b/internal/role/p2p/master.go
@@ -162,7 +162,7 @@ func Master(cc *config.Config, pconfig *providerConfig.Config, clusterInit, ha b
 		// Configure k3s service to start on edgevpn0
 		c.Logger.Info("Configuring k3s")
 
-		utils.SH(fmt.Sprintf("elemental run-stage provider-kairos.bootstrap.before.%s", roleName)) //nolint:errcheck
+		utils.SH(fmt.Sprintf("kairos-agent run-stage provider-kairos.bootstrap.before.%s", roleName)) //nolint:errcheck
 
 		svc, err := machine.K3s()
 		if err != nil {
@@ -222,7 +222,7 @@ func Master(cc *config.Config, pconfig *providerConfig.Config, clusterInit, ha b
 			return err
 		}
 
-		utils.SH(fmt.Sprintf("elemental run-stage provider-kairos.bootstrap.after.%s", roleName)) //nolint:errcheck
+		utils.SH(fmt.Sprintf("kairos-agent run-stage provider-kairos.bootstrap.after.%s", roleName)) //nolint:errcheck
 
 		return role.CreateSentinel()
 	}

--- a/internal/role/p2p/worker.go
+++ b/internal/role/p2p/worker.go
@@ -89,7 +89,7 @@ func Worker(cc *config.Config, pconfig *providerConfig.Config) role.Role { //nol
 
 		c.Logger.Info("Configuring k3s-agent", masterIP, nodeToken, args)
 
-		utils.SH(fmt.Sprintf("elemental run-stage provider-kairos.bootstrap.before.%s", "worker")) //nolint:errcheck
+		utils.SH(fmt.Sprintf("kairos-agent run-stage provider-kairos.bootstrap.before.%s", "worker")) //nolint:errcheck
 
 		// Setup systemd unit and starts it
 		if err := utils.WriteEnv(machine.K3sEnvUnit("k3s-agent"),
@@ -120,7 +120,7 @@ func Worker(cc *config.Config, pconfig *providerConfig.Config) role.Role { //nol
 			return err
 		}
 
-		utils.SH(fmt.Sprintf("elemental run-stage provider-kairos.bootstrap.after.%s", "worker")) //nolint:errcheck
+		utils.SH(fmt.Sprintf("kairos-agent run-stage provider-kairos.bootstrap.after.%s", "worker")) //nolint:errcheck
 
 		return role.CreateSentinel()
 	}


### PR DESCRIPTION
No longer used, move to kairos-agent

Also drop sha iso calculation as its done by the iso builder automatically

Fixes https://github.com/kairos-io/kairos/issues/1798