### PR TITLE
Set the proper yaml section for p2p

### DIFF
--- a/internal/provider/interactive-install.go
+++ b/internal/provider/interactive-install.go
@@ -12,7 +12,7 @@ import (
 func InteractiveInstall(e *pluggable.Event) pluggable.EventResponse { //nolint:revive
 	prompts := []bus.YAMLPrompt{
 		{
-			YAMLSection: "kairos.network_token",
+			YAMLSection: "p2p.network_token",
 			Prompt:      "Insert a network token, leave empty to autogenerate",
 			AskFirst:    true,
 			AskPrompt:   "Do you want to setup a full mesh-support?",


### PR DESCRIPTION
It was being set to kairos key but the proper key is p2p

Fixes: https://github.com/kairos-io/kairos/issues/1922