### PR TITLE
:bug: Fix kairosctl goreleaser build

### DIFF
--- a/.github/workflows/release_bin.yaml
+++ b/.github/workflows/release_bin.yaml
@@ -19,19 +19,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18'
+          go-version-file: 'go.mod'
       - name: (dry-run) GoReleaser
         if: startsWith(github.ref_name, 'test-goreleaser')
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --skip-validate --skip-publish
+          args: release --skip=validate,publish
       - name: Run GoReleaser
         if: startsWith(github.ref_name, 'test-goreleaser') != true
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ env.VERSION }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,6 @@ builds:
     id: "kairosctl"
     binary: "kairosctl"
 source:
-  rlcp: true
   enabled: true
   name_template: 'kairos-cli-{{ .Tag }}-source'
 archives:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kairos-io/provider-kairos/v2
 
-go 1.18
+// as soon as https://github.com/kairos-io/provider-kairos/actions/runs/6123251646/job/16620757329#step:7:224
+// is fixed, we are able to switch to go 1.21
+go 1.20
 
 replace github.com/elastic/gosigar => github.com/mudler/gosigar v0.14.3-0.20220502202347-34be910bdaaf
 


### PR DESCRIPTION
* drop rlcp: true -> https://goreleaser.com/deprecations#sourcerlcp
* switch to --clean arg -> https://goreleaser.com/deprecations#-rm-dist
* pin golang version -> https://github.com/kairos-io/provider-kairos/actions/runs/6123251646/job/16620757329#step:7:224