### PR TITLE
feat(kubevip): static pod support

### DIFF
--- a/internal/provider/config/config.go
+++ b/internal/provider/config/config.go
@@ -45,6 +45,7 @@ type KubeVIP struct {
 	ManifestURL string   `yaml:"manifest_url,omitempty"`
 	Interface   string   `yaml:"interface,omitempty"`
 	Enable      *bool    `yaml:"enable,omitempty"`
+	StaticPod   bool     `yaml:"static_pod,omitempty"`
 }
 
 func (k KubeVIP) IsEnabled() bool {


### PR DESCRIPTION
Closes https://github.com/kairos-io/kairos/issues/1993

To use:

```
kubevip:
  static_pod: true
```

I'm still getting my build environment set up so unfortunately I can't test this functionality myself but the change should be straightforward. Please review with this in mind, I definitely could have missed something.