### PR TITLE
Remove warning preventing to bump Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/kairos-io/provider-kairos/v2
 
-// as soon as https://github.com/kairos-io/provider-kairos/actions/runs/6123251646/job/16620757329#step:7:224
-// is fixed, we are able to switch to go 1.21
 go 1.21
 
 replace github.com/elastic/gosigar => github.com/mudler/gosigar v0.14.3-0.20220502202347-34be910bdaaf


### PR DESCRIPTION
v2.6.5 uses 1.21 and didn't break on release

Just want to have another pair of 👀 in case there was something else related to this comment