### PR TITLE
feat(embedded registry): allow to enable embedded registry

### DIFF
--- a/internal/provider/config/config.go
+++ b/internal/provider/config/config.go
@@ -72,9 +72,10 @@ type HA struct {
 }
 
 type K3s struct {
-	Env         map[string]string `yaml:"env,omitempty"`
-	ReplaceEnv  bool              `yaml:"replace_env,omitempty"`
-	ReplaceArgs bool              `yaml:"replace_args,omitempty"`
-	Args        []string          `yaml:"args,omitempty"`
-	Enabled     bool              `yaml:"enabled,omitempty"`
+	Env              map[string]string `yaml:"env,omitempty"`
+	ReplaceEnv       bool              `yaml:"replace_env,omitempty"`
+	ReplaceArgs      bool              `yaml:"replace_args,omitempty"`
+	Args             []string          `yaml:"args,omitempty"`
+	Enabled          bool              `yaml:"enabled,omitempty"`
+	EmbeddedRegistry bool              `yaml:"embedded_registry,omitempty"`
 }

--- a/internal/role/p2p/master.go
+++ b/internal/role/p2p/master.go
@@ -81,6 +81,10 @@ func genArgs(pconfig *providerConfig.Config, ip, ifaceIP string) (args []string)
 		args = append(args, fmt.Sprintf("--tls-san=%s", ip), fmt.Sprintf("--node-ip=%s", ifaceIP))
 	}
 
+	if pconfig.K3s.EmbeddedRegistry {
+		args = append(args, "--embedded-registry")
+	}
+
 	return
 }
 


### PR DESCRIPTION
This is a simple way to enable Spegel with k3s by following https://docs.k3s.io/installation/registry-mirror?_highlight=spegel .

Part of https://github.com/kairos-io/kairos/issues/3100