### PR TITLE
Add p2p ha configuration for k0s

### DIFF
--- a/internal/cli/role.go
+++ b/internal/cli/role.go
@@ -43,10 +43,15 @@ var RoleCMD = cli.Command{
 					c.String("network-id"),
 					edgeVPNClient.NewClient(edgeVPNClient.WithHost(c.String("api"))))
 				advertizing, _ := cc.AdvertizingNodes()
-				fmt.Println("Node\tRole")
+				fmt.Printf("%-47s  %-30s  %-15s\n", "Node", "Role", "IP")
+				fmt.Printf("%s  %s  %s\n",
+					"-----------------------------------------------",
+					"------------------------------",
+					"---------------")
 				for _, a := range advertizing {
 					role, _ := cc.Get("role", a)
-					fmt.Printf("%s\t%s\n", a, role)
+					ip, _ := cc.Get("ip", a)
+					fmt.Printf("%-47s  %-30s  %-15s\n", a, role, ip)
 				}
 				return nil
 			},

--- a/internal/role/p2p/k0s.go
+++ b/internal/role/p2p/k0s.go
@@ -134,7 +134,7 @@ func (k *K0sNode) GenArgs() ([]string, error) {
 	}
 
 	if k.HA() && !k.ClusterInit() {
-		return args, errors.New("HA is not yet supported with k0s")
+		args = append(args, "--token-file /etc/k0s/token")
 	}
 
 	// when we start implementing this functionality, remember to use

--- a/internal/role/p2p/master.go
+++ b/internal/role/p2p/master.go
@@ -83,6 +83,9 @@ func Master(cc *config.Config, pconfig *providerConfig.Config, roleName string) 
 		if ip == "" {
 			return errors.New("node doesn't have an ip yet")
 		}
+		if err := c.Client.Set("ip", c.UUID, ip); err != nil {
+			c.Logger.Error(err)
+		}
 
 		c.Logger.Info("Checking role assignment")
 

--- a/internal/role/p2p/worker.go
+++ b/internal/role/p2p/worker.go
@@ -41,6 +41,12 @@ func Worker(cc *config.Config, pconfig *providerConfig.Config) role.Role { //nol
 		}
 
 		ip := guessIP(pconfig)
+		if ip != "" {
+			if err := c.Client.Set("ip", c.UUID, ip); err != nil {
+				c.Logger.Error(err)
+			}
+		}
+
 		node.SetRole(RoleWorker)
 		node.SetRoleConfig(c)
 		node.SetIP(ip)


### PR DESCRIPTION
It also extends the `role list` command to show the edgevpn ips of the nodes so it's easier to just jump to the clusterinit one and manage the cluster from there