### PR TITLE
3100 fix embedded registry config

### DIFF
--- a/internal/role/p2p/k3s.go
+++ b/internal/role/p2p/k3s.go
@@ -281,11 +281,19 @@ func (k *K3sNode) Env() map[string]string {
 
 func (k *K3sNode) Args() []string {
 	c := k.ProviderConfig()
+	var args []string
+
 	if k.IsWorker() {
-		return c.K3sAgent.Args
+		args = c.K3sAgent.Args
+	} else {
+		args = c.K3s.Args
+		// Add embedded registry flag if enabled (for non-p2p mode, server only)
+		if c.K3s.EmbeddedRegistry {
+			args = append(args, "--embedded-registry")
+		}
 	}
 
-	return c.K3s.Args
+	return args
 }
 
 func (k *K3sNode) EnvFile() string {

--- a/internal/role/p2p/k3s_test.go
+++ b/internal/role/p2p/k3s_test.go
@@ -1,0 +1,97 @@
+package role
+
+import (
+	providerConfig "github.com/kairos-io/provider-kairos/v2/internal/provider/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("K3sNode Args", func() {
+	Context("embedded registry flag", func() {
+		It("should include --embedded-registry flag for master when enabled", func() {
+			config := &providerConfig.Config{
+				K3s: providerConfig.K3s{
+					Enabled:          true,
+					EmbeddedRegistry: true,
+					Args:             []string{"--existing-arg"},
+				},
+			}
+
+			node := &K3sNode{
+				providerConfig: config,
+				role:           "master",
+			}
+
+			args := node.Args()
+
+			Expect(args).To(ContainElement("--existing-arg"))
+			Expect(args).To(ContainElement("--embedded-registry"))
+		})
+
+		It("should not include --embedded-registry flag for worker when enabled", func() {
+			config := &providerConfig.Config{
+				K3s: providerConfig.K3s{
+					Enabled:          true,
+					EmbeddedRegistry: true,
+					Args:             []string{"--existing-arg"},
+				},
+				K3sAgent: providerConfig.K3s{
+					Enabled: true,
+					Args:    []string{"--worker-arg"},
+				},
+			}
+
+			node := &K3sNode{
+				providerConfig: config,
+				role:           "worker",
+			}
+
+			args := node.Args()
+
+			Expect(args).To(ContainElement("--worker-arg"))
+			Expect(args).NotTo(ContainElement("--embedded-registry"))
+		})
+
+		It("should not include --embedded-registry flag when disabled", func() {
+			config := &providerConfig.Config{
+				K3s: providerConfig.K3s{
+					Enabled:          true,
+					EmbeddedRegistry: false,
+					Args:             []string{"--existing-arg"},
+				},
+			}
+
+			node := &K3sNode{
+				providerConfig: config,
+				role:           "master",
+			}
+
+			args := node.Args()
+
+			Expect(args).To(ContainElement("--existing-arg"))
+			Expect(args).NotTo(ContainElement("--embedded-registry"))
+		})
+
+		It("should preserve existing args when embedded registry is enabled", func() {
+			config := &providerConfig.Config{
+				K3s: providerConfig.K3s{
+					Enabled:          true,
+					EmbeddedRegistry: true,
+					Args:             []string{"--arg1", "--arg2"},
+				},
+			}
+
+			node := &K3sNode{
+				providerConfig: config,
+				role:           "master",
+			}
+
+			args := node.Args()
+
+			Expect(args).To(ContainElement("--arg1"))
+			Expect(args).To(ContainElement("--arg2"))
+			Expect(args).To(ContainElement("--embedded-registry"))
+			Expect(len(args)).To(Equal(3))
+		})
+	})
+})

--- a/internal/role/p2p/suite_test.go
+++ b/internal/role/p2p/suite_test.go
@@ -1,0 +1,13 @@
+package role
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestP2P(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "P2P Suite")
+}


### PR DESCRIPTION
Part of: https://github.com/kairos-io/kairos/issues/3100
fixing the manual setup case.

A config similar to this should now work:

master:

```yaml
hostname: metal-{{ trunc 4 .MachineID }}
users:
- name: kairos # Change to your own user
  passwd: kairos # Change to your own password
  groups:
    - admin # This user needs to be part of the admin group


k3s:
  enabled: true
  embedded_registry: true

stages:
  boot:
    - name: "Add registries configuration for k3s/spegel"
      files:
        - path: /etc/rancher/k3s/registries.yaml
          content: |
            mirrors:
              "*":
```

worker:

```yaml
#cloud-config

hostname: metal-{{ trunc 4 .MachineID }}
users:
- name: kairos # Change to your own user
  passwd: kairos # Change to your own password
  groups:
    - admin # This user needs to be part of the admin group

k3s-agent: # Warning: the key is different from the master node one
  enabled: true
  args:
    - --with-node-id # will configure the agent to use the node ID to communicate with the master node
  env:
    K3S_TOKEN: "<token-from-master-/var/lib/rancher/k3s/server/node-token"
    K3S_URL: https://<master-ip-address-here>:6443 # Same IP that you use to log into your master node

stages:
  boot:
    - name: "Add registries configuration for k3s/spegel"
      files:
        - path: /etc/rancher/k3s/registries.yaml
          content: |
            mirrors:
              "*":
```

documentation: https://docs.k3s.io/installation/registry-mirror#enabling-registry-mirroring
