### PR TITLE
feat: Add riscv64 architecture support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
     binary: "provider-kairos"
     id: provider-kairos
     main: ./main.go


### PR DESCRIPTION
- Added `riscv64` to the list of supported architectures in .goreleaser.yaml
- This change enables building for the RISC-V architecture, expanding compatibility with various platforms.