### PR TITLE
feat(cli): allow --api and --network-id to be set via environment

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -22,14 +22,18 @@ var Author = "Ettore Di Giacinto"
 
 var networkAPI = []cli.Flag{
 	&cli.StringFlag{
-		Name:  "api",
-		Usage: "API Address",
-		Value: "http://localhost:8080",
+		Name: "api",
+		Usage: "Edgevpn API endpoint. Accepts a TCP URL (e.g. http://127.0.0.1:8080) " +
+			"or a unix socket path with the 'unix://' prefix (e.g. unix:///run/edgevpn.sock). " +
+			"Match this to whatever the local edgevpn daemon's APILISTEN is set to.",
+		Value:   "http://localhost:8080",
+		EnvVars: []string{"EDGEVPN_API"},
 	},
 	&cli.StringFlag{
-		Name:  "network-id",
-		Value: "kairos",
-		Usage: "Kubernetes Network Deployment ID",
+		Name:    "network-id",
+		Value:   "kairos",
+		Usage:   "Kubernetes Network Deployment ID",
+		EnvVars: []string{"EDGEVPN_NETWORK_ID"},
 	},
 }
 


### PR DESCRIPTION
The edgevpn `--api` flag tells the role-coordination commands (and the get-kubeconfig / bridge commands) where to reach the local edgevpn daemon. Until now it was a CLI-only flag with a hard-coded default of `http://localhost:8080`. The default works when the daemon's APILISTEN is left at its own default (also `127.0.0.1:8080`), but breaks every deployment that locks the daemon down behind a unix socket — the default flows in, edgeVPNClient.NewClient(WithHost("http://localhost:8080")) gets ECONNREFUSED, and the role loop sees zero active nodes forever.

edgevpn's api/client already understands `unix://<path>` hosts since v0.34.0 (WithHost swaps in a unix-socket Transport when it sees the prefix). The only missing piece is a way for operators to *tell* this package what scheme/address to use without re-wrapping the binary in a shell flag. Adding `EnvVars: []string{"EDGEVPN_API"}` exposes the flag on the systemd-side configuration surface that everything else already uses (drop-ins, EnvironmentFile, Environment=) and unblocks unix-socket deployments via a single line of cluster config:

  Environment=EDGEVPN_API=unix:///run/edgevpn-kairos.sock

For symmetry, `--network-id` gets the same treatment via `EDGEVPN_NETWORK_ID` — same operator surface, no special-casing.

No behavioral change when neither env var is set.