### PR TITLE
feat(bootstrap): honor EDGEVPN_API env for the bootstrap event handler

### DIFF
--- a/internal/provider/bootstrap.go
+++ b/internal/provider/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kairos-io/kairos-sdk/bus"
@@ -64,12 +65,30 @@ func Bootstrap(e *pluggable.Event) pluggable.EventResponse {
 
 	logger := loggerpkg.NewKairosLogger("provider", logLevel, false)
 
+	// Let operators override the edgevpn API endpoint via EDGEVPN_API so the
+	// bootstrap path can target a unix socket (or any non-default listener)
+	// without rebuilding the binary or threading a flag through kairos-sdk's
+	// bus payload. Without this, cfg.APIAddress flows in with the kairos-agent
+	// default (http://localhost:8080) and the role-coordination client sits
+	// at "Active nodes:[]" forever whenever the daemon has been moved off
+	// that address (e.g. APILISTEN=unix:///run/edgevpn-kairos.sock under a
+	// hardened systemd-managed deployment). The same value also flows into
+	// the SetupVPN/SetupAPI calls below — those write APILISTEN into the
+	// edgevpn daemon env file as a fallback default, which keeps daemon and
+	// client in agreement out of the box (cloud-config p2p.vpn.env still
+	// wins when an operator wants daemon-vs-client asymmetry).
+	apiAddress := cfg.APIAddress
+	if v := os.Getenv("EDGEVPN_API"); v != "" {
+		logger.Info("Overriding edgevpn API endpoint from EDGEVPN_API env: ", v)
+		apiAddress = v
+	}
+
 	// Do onetimebootstrap if a Kubernetes distribution is enabled.
 	// Those blocks are not required to be enabled in case of a kairos
 	// full automated setup. Otherwise, they must be explicitly enabled.
 	if (tokenNotDefined && prvConfig.IsKubernetesConfigured()) || skipAuto {
 		err := oneTimeBootstrap(logger, prvConfig, func() error {
-			return SetupVPN(services.EdgeVPNDefaultInstance, cfg.APIAddress, "/", true, prvConfig)
+			return SetupVPN(services.EdgeVPNDefaultInstance, apiAddress, "/", true, prvConfig)
 		})
 		if err != nil {
 			return ErrorEvent("Failed setup: %s", err.Error())
@@ -84,12 +103,12 @@ func Bootstrap(e *pluggable.Event) pluggable.EventResponse {
 	// We might still want a VPN, but not to route traffic into
 	if prvConfig.P2P.VPNNeedsCreation() {
 		logger.Info("Configuring VPN")
-		if err := SetupVPN(services.EdgeVPNDefaultInstance, cfg.APIAddress, "/", true, prvConfig); err != nil {
+		if err := SetupVPN(services.EdgeVPNDefaultInstance, apiAddress, "/", true, prvConfig); err != nil {
 			return ErrorEvent("Failed setup VPN: %s", err.Error())
 		}
 	} else { // We need at least the API to co-ordinate
 		logger.Info("Configuring API")
-		if err := SetupAPI(cfg.APIAddress, "/", true, prvConfig); err != nil {
+		if err := SetupAPI(apiAddress, "/", true, prvConfig); err != nil {
 			return ErrorEvent("Failed setup VPN: %s", err.Error())
 		}
 	}
@@ -102,7 +121,7 @@ func Bootstrap(e *pluggable.Event) pluggable.EventResponse {
 
 	cc := service.NewClient(
 		networkID,
-		edgeVPNClient.NewClient(edgeVPNClient.WithHost(cfg.APIAddress)))
+		edgeVPNClient.NewClient(edgeVPNClient.WithHost(apiAddress)))
 
 	nodeOpts := []service.Option{
 		service.WithMinNodes(prvConfig.P2P.MinimumNodes),


### PR DESCRIPTION
#913 wired EDGEVPN_API into the --api flag for the role / get-kubeconfig / bridge subcommands, but missed the bootstrap path that the kairos-agent event bus actually invokes at boot. That handler lives in internal/provider/bootstrap.go and pulls its API address from bus.BootstrapPayload.APIAddress (a JSON field in the event payload), which is fixed at whatever kairos-agent decides to send — typically the hard-coded http://localhost:8080 default.

The symptom on a deployment that locks the daemon behind a unix socket (APILISTEN=unix:///run/edgevpn-kairos.sock) is:

  kairos-provider[1469]: Active nodes:[]
  kairos-provider[1469]: Advertizing nodes:[]
  kairos-provider[1469]: not enough nodes available, sleeping...

…even though edgevpn itself sees the full peer mesh: the role client keeps dialing TCP localhost:8080 (closed) instead of the socket.

This change reads EDGEVPN_API once near the top of Bootstrap() and uses the resolved value everywhere the function previously referenced cfg.APIAddress (the role client at line 105, plus the SetupVPN / SetupAPI default propagated into APILISTEN). The cloud-config p2p.vpn.env override still wins when an operator wants daemon and client to talk over different addresses; this is just the env-driven default.

Composes with #913 — together, every consumer of the edgevpn local API in this binary honors EDGEVPN_API.

No behavioral change when EDGEVPN_API is unset.