### PR TITLE
chore: build with Go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kairos-io/provider-kairos/v2
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/elastic/gosigar => github.com/mudler/gosigar v0.14.3-0.20220502202347-34be910bdaaf
 


### PR DESCRIPTION
Eight Go standard library advisories affect the `provider-kairos` binary bundled by `kairos-init`, and they are among the 18 that failed the Kairos release gate on `v4.2.0-rc2`:

`GO-2026-5026`, `GO-2026-5942`, `GO-2026-5972`, `GO-2026-6088`, `GO-2026-6089`, `GO-2026-6090`, `GO-2026-6091`, `GO-2026-6218`

All eight are fixed in **Go 1.26.6**, a stable release. No prerelease toolchain is involved.

## The change is one line

CI takes its toolchain from `go-version-file: go.mod` in both `test.yml` and `release.yaml`, so the directive is the only thing that needs to move:

```diff
-go 1.26.5
+go 1.26.6
```

Verified with `go build ./...`, clean.

## Why nothing else changes here

Worth stating, because the rc2 scan named six modules against this binary and it would be easy to bump all of them for no effect.

`github.com/klauspost/compress`, `go.opentelemetry.io/otel`, `golang.org/x/image`, `golang.org/x/net` and `google.golang.org/grpc` are **already at or above their fixed versions** in `go.mod` today:

| module | in the shipped bundle | fixed in | here today |
|---|---|---|---|
| klauspost/compress | 1.18.6 | 1.18.7 | v1.19.1 |
| go.opentelemetry.io/otel | 1.43.0 | 1.44.0 | v1.45.0 |
| golang.org/x/image | 0.41.0 | 0.43.0 | v0.43.0 |
| google.golang.org/grpc | 1.81.1 | 1.82.1 | v1.83.0 |
| golang.org/x/net | 0.55.0 | — | v0.57.0 |

They appear in the scan because **the bundle is built from an older release of this component**, not because this repository is behind. Those clear on a rebuild and a `kairos-init` pin bump, not on a dependency change.

The Go directive is the one thing that is genuinely still behind.
