### PR TITLE
fix(deps): bump golang.org/x/image to v0.45.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -292,7 +292,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/image v0.43.0 // indirect
+	golang.org/x/image v0.45.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
@@ -300,7 +300,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/go.sum
+++ b/go.sum
@@ -1035,6 +1035,8 @@ golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+o
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
 golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1259,6 +1261,8 @@ golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
 golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
## What this does

Bumps the indirect dependency `golang.org/x/image` from `v0.43.0` to `v0.45.0`.

## Why

OSV published `GO-2026-6222` (alias `CVE-2026-46603`) on 2026-08-14: excessive memory allocation during VP8L decoding in `golang.org/x/image`. The fix is `v0.45.0`.

The release vulnerability scan for [v4.2.0-rc3](https://github.com/kairos-io/kairos/releases/tag/v4.2.0-rc3) fails on this advisory. It is the **only** unignored finding in the shipped bundle — the scan reports `1 unignored advisories (1 findings)`. `Release AMD64 artifacts` and `Release ARM artifacts` both stop there, so rc3 published no assets.

The advisory reaches the release through the `kairos-agent` and `provider-kairos` binaries that `kairos-init` bundles. The scan flags all four copies: the FIPS and the non-FIPS build of each.

This PR fixes the `provider-kairos` half. The `kairos-agent` half is [kairos-io/kairos-agent#1342](https://github.com/kairos-io/kairos-agent/pull/1342).

## How the dependency arrives

It is indirect:

```
provider-kairos/internal/cli
  -> kairos-io/go-nodepair/qrcode
    -> eliukblau/pixterm/pkg/ansimage
      -> golang.org/x/image/bmp
```

## Scope of the change

`go.mod` and `go.sum` only. Two lines in `go.mod`: `golang.org/x/text` moves from `v0.40.0` to `v0.41.0`, because `golang.org/x/image v0.45.0` requires it.

**This PR does not run `go mod tidy`.** A tidy on current `main` removes 30 unrelated lines from `go.sum`. That churn does not belong in a security bump, so it is left for a separate PR.

## Verification

`go build ./...` and `go vet ./...` pass.

## What still has to happen for 4.2.0

This bump alone does not clear the release. It needs a `kairos-agent` release, a `provider-kairos` release, a `kairos-init` release, and then a pin bump in `kairos`.
